### PR TITLE
OpenaiProcessors.generateOverallSummary で反復して API をコールするように変更

### DIFF
--- a/packages/processors/base/utils/batch.ts
+++ b/packages/processors/base/utils/batch.ts
@@ -1,0 +1,41 @@
+/**
+ * Create horizontal batches by slicing array sequentially
+ * @param entries Array to batch
+ * @param batchSize Size of each batch
+ * @returns Array of batches
+ */
+export function createHorizontalBatches<T>(entries: T[], batchSize: number): T[][] {
+  const batches = [];
+  for (let i = 0; i < entries.length; i += batchSize) {
+    batches.push(entries.slice(i, i + batchSize));
+  }
+  return batches;
+}
+
+/**
+ * Create vertical batches by grouping elements at same positions across chunks
+ * @param entries Array to batch
+ * @param batchSize Size of each batch
+ * @returns Array of batches
+ */
+export function createVerticalBatches<T>(entries: T[], batchSize: number): T[][] {
+  const chunkSize = Math.ceil(entries.length / batchSize);
+  
+  // Split entries into chunks
+  const chunks: T[][] = [];
+  for (let i = 0; i < entries.length; i += chunkSize) {
+    chunks.push(entries.slice(i, i + chunkSize));
+  }
+  
+  // Group elements vertically
+  const batches: T[][] = [];
+  for (let pos = 0; pos < chunkSize; pos++) {
+    const batch = chunks
+      .map(chunk => chunk[pos])
+      .filter((entry): entry is T => entry !== undefined);
+    if (batch.length > 0) {
+      batches.push(batch);
+    }
+  }
+  return batches;
+}

--- a/packages/processors/openai/internal/aspects.ts
+++ b/packages/processors/openai/internal/aspects.ts
@@ -1,0 +1,68 @@
+/**
+ * Review aspect definition types and defaults
+ */
+
+export interface ReviewAspect {
+  /** Unique identifier for the aspect */
+  key: string;
+  /** Display name of the aspect */
+  name: string;
+  /** Detailed description of what this aspect covers */
+  description: string;
+}
+
+/**
+ * Default review aspects covering common code review perspectives
+ */
+export const defaultReviewAspects: ReviewAspect[] = [
+  {
+    key: "performance",
+    name: "Performance",
+    description: "Aspects related to code execution speed and efficiency",
+  },
+  {
+    key: "security",
+    name: "Security",
+    description: "Aspects related to vulnerabilities and security risks",
+  },
+  {
+    key: "testability",
+    name: "Testability",
+    description: "Aspects related to ease of testing and code coverage",
+  },
+  {
+    key: "error_handling",
+    name: "Error Handling",
+    description: "Aspects related to exception handling and error management",
+  },
+  {
+    key: "maintainability",
+    name: "Maintainability",
+    description: "Aspects related to code clarity, understandability, and ease of future maintenance and extension",
+  },
+  {
+    key: "documentation",
+    name: "Documentation",
+    description: "Aspects related to appropriateness of comments and explanations",
+  },
+  {
+    key: "architecture",
+    name: "Architecture",
+    description: "Aspects related to design patterns and code structure",
+  },
+  {
+    key: "naming",
+    name: "Naming Conventions",
+    description: "Aspects related to naming of variables, functions, and other identifiers",
+  },
+  {
+    key: "code_style",
+    name: "Code Style",
+    description: "Aspects related to formatting, indentation, and coding style",
+  },
+  {
+    key: "resource_management",
+    name: "Resource Management",
+    description: "Aspects related to management of memory, file handles, and other resources",
+  },
+];

--- a/packages/processors/openai/internal/prompts.ts
+++ b/packages/processors/openai/internal/prompts.ts
@@ -108,15 +108,14 @@ ${summarizeResults.map(r => `- ${r.path}: ${r.summary || 'No summary available'}
 Analyze the current batch files and respond with:
 1. Description focusing ONLY on the current batch files
 2. Aspect mappings for current batch files:
-   - Try to use standard aspects from the provided list where applicable
+   - Apply ALL relevant standard aspects that naturally fit the changes
+   - Each file can have multiple aspects if they are significantly relevant
    - Feel free to create new aspects if the changes don't fit well with any standard aspects
-   - For each aspect, explain how it relates to the specific changes
 
 Important rules:
 - Focus ONLY on files listed in "Current Batch Files"
-- Try to use standard aspects where they naturally fit the changes
-- Create new aspects if the changes can't be well described by standard aspects
-- Make sure each aspect description clearly explains its relevance to the current changes
+- Apply multiple aspects to a file if they are relevant
+- Make sure each aspect description clearly explains its relationship to the changes
 
 Expected JSON format:
 {

--- a/packages/processors/openai/internal/prompts.ts
+++ b/packages/processors/openai/internal/prompts.ts
@@ -139,7 +139,29 @@ Create a comprehensive analysis:
 1. For elements requiring semantic integration:
    - description: Create a comprehensive overview integrating all changes
    - aspect.description: Update descriptions to reflect the current understanding
-   - crossCuttingConcerns: Maintain and extend concerns based on all changes
+   - crossCuttingConcerns:
+     What to identify:
+     - System-wide implications that:
+       - Affect multiple aspects or domains
+       - Require broader consideration beyond individual files
+       - Impact development practices or processes
+     
+     Examples:
+     - Security policy changes affecting multiple components
+     - Documentation updates needed across the system
+     - Performance implications spanning multiple modules
+     - Testing strategy adjustments
+     - Dependency updates requiring system-wide changes
+     - Changes to development or deployment processes
+
+     Integration with previous concerns:
+     - Review each previous concern and assess its current relevance
+     - Maintain concerns that are still applicable to the system
+     - Update concern descriptions to reflect new understanding
+     - Add new concerns arising from current changes
+     - Combine related concerns into more comprehensive descriptions
+     - Remove concerns that are no longer relevant
+     - Ensure all maintained concerns reflect current state
 
 2. For aspect mappings:
    - Analyze ONLY the current files for both standard and domain aspects
@@ -182,8 +204,14 @@ Expected JSON format:
       "files": string[]      // Files from current batch in this domain
     }
   ],
-  "crossCuttingConcerns": string[] // Cross-cutting concerns specific to current batch
+  "crossCuttingConcerns": string[] // System-wide implications requiring broader consideration
 }
+
+Note about cross-cutting concerns:
+- Focus on implications that span multiple components
+- Consider both technical and process-related impacts
+- Identify concerns that might require coordination across teams
+- Flag issues that could affect future maintenance or development
 `;
 
 /**

--- a/packages/processors/openai/internal/prompts.ts
+++ b/packages/processors/openai/internal/prompts.ts
@@ -77,15 +77,18 @@ export const createGroupingPrompt = ({
   summarizeResults: { path: string; needsReview: boolean, summary?: string, reason?: string }[];
   previousAnalysis?: string;
   aspects?: ReviewAspect[];
-}) => `You are analyzing changes in the current batch of a pull request.
+}) => `You are analyzing code changes in a pull request.
 
-${previousAnalysis ? `## Previous Analysis (Reference for aspect consistency)
-The following analysis from previous batches should be used as reference to maintain consistent aspect categorization:
+${previousAnalysis ? `## Previous Analysis
+The following analysis provides context for your review:
 
 ${previousAnalysis}
 
-Note: Previous analysis provides context for aspect reuse only.
-Do NOT include previous files or concerns in your response.\n` : ''}
+Note:
+- Use previous analysis to maintain consistent aspect categorization
+- Create a comprehensive description that covers all changes cohesively
+- Present changes as a logically connected whole
+- Only analyze listed files for aspect mappings\n` : ''}
 
 ## Pull Request
 
@@ -97,29 +100,32 @@ Use these standard aspects as a guide for your analysis:
 ${aspects.map(a => `- ${a.name} (key: "${a.key}")
   ${a.description}`).join('\n')}
 
-## Current Batch Files
+## Files To Analyze
 
 ${files.map(f => `### ${f.path}\n\n\`\`\`diff\n${f.patch}\n\`\`\`\n`).join('\n')}
 
-## Current Batch Summaries
+## Change Summaries
 
 ${summarizeResults.map(r => `- ${r.path}: ${r.summary || 'No summary available'}`).join('\n')}
 
-Analyze the current batch files and respond with:
-1. Description focusing ONLY on the current batch files
-2. Aspect mappings for current batch files:
+Create a comprehensive analysis:
+1. Description that:
+   - Presents all changes as a cohesive and logically connected whole
+   - Explains the overall purpose and impact of the changes
+   - Focuses on relationships between different modifications
+2. Aspect mappings for the provided files:
    - Apply ALL relevant standard aspects that naturally fit the changes
    - Each file can have multiple aspects if they are significantly relevant
    - Feel free to create new aspects if the changes don't fit well with any standard aspects
 
 Important rules:
-- Focus ONLY on files listed in "Current Batch Files"
-- Apply multiple aspects to a file if they are relevant
-- Make sure each aspect description clearly explains its relationship to the changes
+- Only analyze the listed files for aspect mappings
+- Create a unified description of the entire change set
+- Ensure each aspect description explains its specific impact
 
 Expected JSON format:
 {
-  "description": string, // Description of current batch changes only
+  "description": string, // Comprehensive description integrating previous and current changes
   "aspectMappings": [
     {
       "aspect": {

--- a/packages/processors/openai/internal/prompts.ts
+++ b/packages/processors/openai/internal/prompts.ts
@@ -65,46 +65,63 @@ export const createGroupingPrompt = ({
   description,
   files,
   summarizeResults,
+  previousAnalysis,
 }: {
   title: string;
   description: string;
   files: { path: string; patch: string }[];
   summarizeResults: { path: string; needsReview: boolean, summary?: string, reason?: string }[];
-}) => `You are analyzing the overall changes in a pull request to group related changes.
+  previousAnalysis?: string;
+}) => `You are analyzing changes in the current batch of a pull request.
+
+${previousAnalysis ? `## Previous Analysis (Reference for aspect consistency)
+The following analysis from previous batches should be used as reference to maintain consistent aspect categorization:
+
+${previousAnalysis}
+
+Note: Previous analysis provides context for aspect reuse only.
+Do NOT include previous files or concerns in your response.\n` : ''}
 
 ## Pull Request
 
 Title: ${title}
 Description: ${description}
 
-## Files Changed
+## Current Batch Files
 
 ${files.map(f => `### ${f.path}\n\n\`\`\`diff\n${f.patch}\n\`\`\`\n`).join('\n')}
 
-## summarized results
+## Current Batch Summaries
 
 ${summarizeResults.map(r => `- ${r.path}: ${r.summary || 'No summary available'}`).join('\n')}
 
-Analyze these changes and respond with:
-1. Overall description of changes
-2. Aspect summaries for each review aspect based on the summaries in the summarized results
-3. Identify cross-cutting concerns
+Analyze the current batch files and respond with:
+1. Description focusing ONLY on the current batch files
+2. Aspect mappings for current batch files:
+   - Reuse matching aspect keys from previous analysis for consistency
+   - Use new aspect keys for unrelated changes
+   - Previous analysis is ONLY for aspect key reference
+
+Important rules:
+- Focus ONLY on files listed in "Current Batch Files"
+- Do NOT include files from previous analysis
+- Do NOT copy concerns from previous analysis
+- Previous analysis should ONLY guide aspect key choice
 
 Expected JSON format:
 {
-
-  "description": string, // Overall description of changes
+  "description": string, // Description of current batch changes only
   "aspectMappings": [
     {
       "aspect": {
-        "key": string,
-        "description": string,
-        "impact": string // Impact level (high, medium, low)
+        "key": string,       // Reuse existing keys when appropriate
+        "description": string, // Description of current changes
+        "impact": string     // Impact of current changes (high, medium, low)
       },
-      "files": string[],
+      "files": string[],     // Only current batch files
     }
   ],
-  "crossCuttingConcerns": string[] // Optional cross-cutting concerns
+  "crossCuttingConcerns": string[] // Concerns about current batch only
 }
 `;
 

--- a/packages/processors/openai/internal/prompts.ts
+++ b/packages/processors/openai/internal/prompts.ts
@@ -95,10 +95,37 @@ Note:
 Title: ${title}
 Description: ${description}
 
-## Available Review Aspects
-Use these standard aspects as a guide for your analysis:
+## Review Aspects
+
+1. Standard Aspects
+Use these predefined aspects for technical characteristics:
 ${aspects.map(a => `- ${a.name} (key: "${a.key}")
   ${a.description}`).join('\n')}
+
+2. Domain Aspects
+What is a Domain?
+- A domain represents a specific business or functional area that the code addresses
+- Examples:
+  - "Authentication & Authorization": User login, permissions, security tokens
+  - "Payment Processing": Payment methods, transactions, billing
+  - "Data Transformation": Format conversion, validation, normalization
+  - "User Management": User profiles, preferences, roles
+
+How to identify domains:
+- Analyze file's purpose and responsibilities
+- Look for business/functional patterns in:
+  - Code structure and organization
+  - Function and variable names
+  - Class responsibilities
+  - Comments and documentation
+- Consider what real-world problem the code solves
+
+Creating domain aspects:
+- Use format: "domain:<name>" (e.g., domain:auth, domain:payment)
+- Provide description explaining:
+  - What the domain handles
+  - Why this file belongs to the domain
+- Judge impact level in domain context
 
 ## Files To Analyze
 
@@ -115,10 +142,16 @@ Create a comprehensive analysis:
    - crossCuttingConcerns: Maintain and extend concerns based on all changes
 
 2. For aspect mappings:
-   - Analyze ONLY the current files
-   - Add them to appropriate aspects
+   - Analyze ONLY the current files for both standard and domain aspects
+   - For standard aspects:
+     - Add files to relevant technical aspects using provided keys
+     - Explain how the changes relate to each aspect
+   - For domain aspects:
+     - Identify business/functional domains for each file
+     - Create aspects with "domain:<name>" format
+     - Explain domain purpose and why files belong
    - DO NOT remove or modify aspect assignments for files you cannot directly analyze
-   - Focus on extending existing aspects rather than removing them
+   - Maintain both standard and domain aspects from previous analysis
 
 Important rules:
 - Only assign current files to aspects
@@ -130,13 +163,23 @@ Expected JSON format:
 {
   "description": string, // Comprehensive description integrating previous and current changes
   "aspectMappings": [
+    // Standard aspects example:
     {
       "aspect": {
-        "key": string,       // Use standard aspect keys (e.g., "performance", "security")
+        "key": string,       // Standard aspect key (e.g., "performance", "security")
         "description": string, // Specific description of how this aspect applies to current changes
         "impact": string     // Impact level (high, medium, low)
       },
       "files": string[]      // Files from current batch affected by this aspect
+    },
+    // Domain aspects example:
+    {
+      "aspect": {
+        "key": string,       // Domain aspect key (e.g., "domain:auth", "domain:payment")
+        "description": string, // Explain domain purpose and why files belong here
+        "impact": string     // Impact level in domain context (high, medium, low)
+      },
+      "files": string[]      // Files from current batch in this domain
     }
   ],
   "crossCuttingConcerns": string[] // Cross-cutting concerns specific to current batch

--- a/packages/processors/openai/internal/prompts.ts
+++ b/packages/processors/openai/internal/prompts.ts
@@ -109,19 +109,22 @@ ${files.map(f => `### ${f.path}\n\n\`\`\`diff\n${f.patch}\n\`\`\`\n`).join('\n')
 ${summarizeResults.map(r => `- ${r.path}: ${r.summary || 'No summary available'}`).join('\n')}
 
 Create a comprehensive analysis:
-1. Description that:
-   - Presents all changes as a cohesive and logically connected whole
-   - Explains the overall purpose and impact of the changes
-   - Focuses on relationships between different modifications
-2. Aspect mappings for the provided files:
-   - Apply ALL relevant standard aspects that naturally fit the changes
-   - Each file can have multiple aspects if they are significantly relevant
-   - Feel free to create new aspects if the changes don't fit well with any standard aspects
+1. For elements requiring semantic integration:
+   - description: Create a comprehensive overview integrating all changes
+   - aspect.description: Update descriptions to reflect the current understanding
+   - crossCuttingConcerns: Maintain and extend concerns based on all changes
+
+2. For aspect mappings:
+   - Analyze ONLY the current files
+   - Add them to appropriate aspects
+   - DO NOT remove or modify aspect assignments for files you cannot directly analyze
+   - Focus on extending existing aspects rather than removing them
 
 Important rules:
-- Only analyze the listed files for aspect mappings
-- Create a unified description of the entire change set
-- Ensure each aspect description explains its specific impact
+- Only assign current files to aspects
+- Maintain previous file-aspect relationships
+- Update descriptions without invalidating previous assignments
+- Create new aspects only when necessary for current files
 
 Expected JSON format:
 {

--- a/packages/processors/openai/processor.ts
+++ b/packages/processors/openai/processor.ts
@@ -120,7 +120,7 @@ export class OpenaiProcessor extends BaseProcessor {
     let accumulatedResult: OverallSummary | undefined;
     let previousAnalysis: string | undefined;
 
-    // 複数パスでの処理
+    // Begin multi-pass processing
     for (let pass = 1; pass <= PASSES; pass++) {
       console.debug(`Starting pass ${pass}/${PASSES}`);
 
@@ -185,14 +185,14 @@ export class OpenaiProcessor extends BaseProcessor {
 
           const batchResult = OverallSummarySchema.parse(JSON.parse(content));
 
-          // 累積結果の更新
+          // Update accumulated results
           if (accumulatedResult) {
             accumulatedResult = this.mergeOverallSummaries([accumulatedResult, batchResult]);
           } else {
             accumulatedResult = batchResult;
           }
 
-          // 次のバッチのために累積分析結果を更新
+          // Update cumulative analysis for next batch
           previousAnalysis = this.formatPreviousAnalysis(accumulatedResult);
           console.debug(`[Pass ${pass}/${PASSES}] Batch ${batchNumber} complete. Cumulative analysis:`, previousAnalysis);
         } catch (error) {
@@ -306,7 +306,7 @@ export class OpenaiProcessor extends BaseProcessor {
       return latestMapping;
     });
 
-    // 前回のアスペクトで現在言及されていないものを維持
+    // Preserve aspects from previous mappings that are not referenced in current analysis
     const preservedMappings = previousMappings.filter(prev =>
       !latest.aspectMappings.some(curr => curr.aspect.key === prev.aspect.key)
     );

--- a/packages/processors/openai/processor.ts
+++ b/packages/processors/openai/processor.ts
@@ -205,8 +205,8 @@ export class OpenaiProcessor extends BaseProcessor {
    */
   private mergeOverallSummaries(summaries: OverallSummary[]): OverallSummary {
     return {
-      // 説明を結合
-      description: summaries.map(s => s.description).join('\n\n'),
+      // 最新のdescriptionを使用（LLMが統合済み）
+      description: summaries[summaries.length - 1].description,
 
       // アスペクトマッピングをマージ（同じkeyのものは統合）
       aspectMappings: summaries.flatMap(s => s.aspectMappings)


### PR DESCRIPTION
**対象タスク**

LLM に一括で処理を渡すのではなく、小分けに渡すように変更
https://redmine.weseek.co.jp/issues/164561

前回の分析結果を次の LLM 処理にいれるように変更
https://redmine.weseek.co.jp/issues/164562

あらかじめ決められたアスペクトリストからアスペクトを付与するように変更
https://redmine.weseek.co.jp/issues/164563

1ファイルに複数アスペクトを付与してもよいように変更
https://redmine.weseek.co.jp/issues/164564

一度付与したアスペクトを除外しないように変更
https://redmine.weseek.co.jp/issues/164568

レスポンスパラメータで、LLMが関連付け・統合を行うものと、LLMが関連付け・コードが統合を行うものを整理
https://redmine.weseek.co.jp/issues/164565

LLM にドメインアスペクトを自分で考えてもらって付与するように変更
https://redmine.weseek.co.jp/issues/164566

バッチ処理を2回行うように変更
https://redmine.weseek.co.jp/issues/164569

コード内コメントを英語にする
https://redmine.weseek.co.jp/issues/164668

2パス目のバッチのファイルグルーピング方法を変更する
https://redmine.weseek.co.jp/issues/164669