### PR TITLE
Fix/165001 165085 review comment position

### DIFF
--- a/packages/processors/base/processor.ts
+++ b/packages/processors/base/processor.ts
@@ -197,4 +197,19 @@ export abstract class BaseProcessor implements IPullRequestProcessor {
     }
     return body;
   }
+
+  /**
+   * Add line numbers to diff text for GitHub 'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews' API
+   */
+  protected addLineNumbersToDiff(diffText: string | null): string {
+    if (diffText == null) {
+      return 'No changes';
+    }
+
+    const lines = diffText.split('\n');
+    const numberedLines = lines.map((line, index) => {
+      return `${index}: ${line}`;
+    });
+    return numberedLines.join('\n');
+  }
 }

--- a/packages/processors/openai/processor.ts
+++ b/packages/processors/openai/processor.ts
@@ -244,7 +244,7 @@ export class OpenaiProcessor extends BaseProcessor {
           title: prInfo.title,
           description: prInfo.body || '',
           filePath: file.path,
-          patch: file.patch || 'No changes',
+          patch: this.addLineNumbersToDiff(file.patch),
           instructions: this.getInstructionsForFile(file.path, config),
           aspects: summarizeResult.aspects.map((aspect) => ({
             name: aspect.key,


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/165339

## やったこと
- [ram-lab][code-hedgehog] レビューコメントの position が不適切な値になりエラーが発生する
  - 差分範囲外の箇所に書き込もうとして `Unprocessable Entity: "Pull request review thread line must be part of the diff and Pull request review thread diff hunk can't be blank"` エラーが出る問題の修正

## 対応方法
- prompts.ts に Github review API の position のルールを色々と書き加えてもうまくいかなかった
- プロンプトに渡す diff 部分に position で使用する数字をあらかじめ含めて渡すことにより、ほとんどの場合で正確な位置にコメントを追加できるようになった
  - 動作確認: https://github.com/growilabs/code-hedgehog/pull/8/files#diff-326f72730d7f8f8850c8410607642c95824af0bdb862b6e7d3769811c37969b6