### PR TITLE
Feat/166285 166403 add review diff since last review config

### DIFF
--- a/.coderabbitai.yaml.sample
+++ b/.coderabbitai.yaml.sample
@@ -29,3 +29,6 @@ path_filters: |
 
 # シンプルな変更のスキップ設定
 skip_simple_changes: true
+
+# 最後の AI レビュー以降の差分のみをレビュー対象とするか
+review_diff_since_last_review: false

--- a/docs/project-specs/02.core/path-based-config.md
+++ b/docs/project-specs/02.core/path-based-config.md
@@ -40,6 +40,7 @@ limit_reviews_by_labels: # レビュー対象を特定のラベルを持つPRに
 
 # ファイルレベルの制御
 skip_simple_changes: true # シンプルな変更をスキップするか (デフォルト: false)
+review_diff_since_last_review: false # 最後の AI レビュー以降の差分のみをレビュー対象とするか (デフォルト: false)
 path_filters: # レビュー対象外のファイルパス (Globパターン, 除外専用)
   - "dist/**"
   - "**/*.min.js"
@@ -101,6 +102,13 @@ checks:
 -   `true` の場合、シンプルな変更 (フォーマット、コメント、空白行のみ) をレビュー対象外とします。
 -   型: `boolean`
 -   デフォルト: `false`
+
+### review_diff_since_last_review
+
+- `true` の場合、最後の AI レビュー以降に発生した差分のみをレビュー対象とします。
+- これにより、過去にレビュー済みの部分を再度レビューすることを避け、効率的な差分レビューが可能になります。
+- 型: `boolean`
+- デフォルト: `false`
 
 ### path_filters
 

--- a/packages/action/deno.jsonc
+++ b/packages/action/deno.jsonc
@@ -3,6 +3,7 @@
     "@actions/core": "npm:@actions/core@1.11.1",
     "@code-hedgehog/core": "../core/mod.ts",
     "@code-hedgehog/processor-acme": "../processors/acme/mod.ts",
+    "@code-hedgehog/processor-base": "../processors/base/mod.ts",
     "@code-hedgehog/processor-dify": "../processors/dify/mod.ts",
     "@code-hedgehog/processor-openai": "../processors/openai/mod.ts"
   },

--- a/packages/action/src/runner.ts
+++ b/packages/action/src/runner.ts
@@ -3,12 +3,18 @@
 import process from 'node:process';
 import * as core from '@actions/core';
 import { FileManager, type IFileFilter, type IPullRequestProcessor, type IReviewComment, type IVCSConfig, createVCS } from '@code-hedgehog/core';
+import { DEFAULT_CONFIG, type ReviewConfig, loadBaseConfig as loadExternalBaseConfig } from '@code-hedgehog/processor-base';
 import type { ActionConfig } from './config.ts';
 
 export class ActionRunner {
+  // Initialize config with DEFAULT_CONFIG, it will be updated by loadConfig
+  private reviewConfig: ReviewConfig = DEFAULT_CONFIG;
+
   constructor(private readonly config: ActionConfig) {}
 
   async run(): Promise<IReviewComment[]> {
+    await this.loadBaseConfig();
+
     const dryRunEnvVar = process.env.CODE_HEDGEHOG_DRY_RUN_VCS_PROCESSING;
     const dryRun = dryRunEnvVar === 'true' || dryRunEnvVar === '1';
 
@@ -32,7 +38,7 @@ export class ActionRunner {
       const allComments: IReviewComment[] = [];
 
       // Process files in batches and get reviews
-      for await (const files of fileManager.collectChangedFiles()) {
+      for await (const files of fileManager.collectChangedFiles(this.reviewConfig)) {
         const { comments } = await processor.process(prInfo, files);
         allComments.push(...(comments ?? []));
 
@@ -136,5 +142,14 @@ export class ActionRunner {
       exclude: this.config.filter.exclude,
       maxChanges: this.config.filter.maxChanges,
     };
+  }
+
+  /**
+   * Load configuration using the external module.
+   * This method now acts as a wrapper to update the instance's config.
+   */
+  protected async loadBaseConfig(configPath = '.coderabbitai.yaml'): Promise<void> {
+    // Call the external function and update the instance's config
+    this.reviewConfig = await loadExternalBaseConfig(configPath); // Rename function call
   }
 }

--- a/packages/core/deno.jsonc
+++ b/packages/core/deno.jsonc
@@ -2,6 +2,7 @@
   "imports": {
     "@actions/core": "npm:@actions/core@^1.11.1",
     "@actions/github": "npm:@actions/github@^6.0.0",
+    "@code-hedgehog/processor-base": "../processors/base/mod.ts",
     "@octokit/core": "npm:@octokit/core@^5.0.1",
     "@octokit/plugin-rest-endpoint-methods": "npm:@octokit/plugin-rest-endpoint-methods@^10.4.1",
     "@octokit/plugin-paginate-rest": "npm:@octokit/plugin-paginate-rest@^9.2.2",

--- a/packages/core/src/files/file-manager.test.ts
+++ b/packages/core/src/files/file-manager.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CONFIG } from '@code-hedgehog/processor-base';
 import { assertEquals, assertRejects } from '@std/assert';
 
 import type { IFileChange } from '../types/file.ts';
@@ -42,7 +43,7 @@ Deno.test('FileManager.collectChangedFiles', async (t) => {
     });
 
     const result: IFileChange[] = [];
-    for await (const batch of manager.collectChangedFiles()) {
+    for await (const batch of manager.collectChangedFiles(DEFAULT_CONFIG, undefined)) {
       result.push(...batch);
     }
 
@@ -60,7 +61,7 @@ Deno.test('FileManager.collectChangedFiles', async (t) => {
     });
 
     const result: IFileChange[] = [];
-    for await (const batch of manager.collectChangedFiles()) {
+    for await (const batch of manager.collectChangedFiles(DEFAULT_CONFIG, undefined)) {
       result.push(...batch);
     }
 
@@ -82,7 +83,7 @@ Deno.test('FileManager.collectChangedFiles', async (t) => {
     });
 
     const result: IFileChange[] = [];
-    for await (const batch of manager.collectChangedFiles()) {
+    for await (const batch of manager.collectChangedFiles(DEFAULT_CONFIG, undefined)) {
       result.push(...batch);
     }
 
@@ -101,7 +102,7 @@ Deno.test('FileManager.collectChangedFiles', async (t) => {
     const batchSize = 10;
     const batches: IFileChange[][] = [];
 
-    for await (const batch of manager.collectChangedFiles(batchSize)) {
+    for await (const batch of manager.collectChangedFiles(DEFAULT_CONFIG, batchSize)) {
       batches.push(batch);
     }
 
@@ -121,7 +122,7 @@ Deno.test('FileManager.collectChangedFiles', async (t) => {
 
     await assertRejects(
       async () => {
-        for await (const _ of manager.collectChangedFiles()) {
+        for await (const _ of manager.collectChangedFiles(DEFAULT_CONFIG, undefined)) {
           // consume iterator
         }
       },

--- a/packages/core/src/files/file-manager.ts
+++ b/packages/core/src/files/file-manager.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import type { ReviewConfig } from '@code-hedgehog/processor-base';
 import { minimatch } from 'minimatch';
 
 import type { IFileChange, IVersionControlSystem } from '../types/mod.ts';
@@ -11,11 +12,11 @@ export class FileManager implements IFileManager {
     private readonly filter: IFileFilter = {},
   ) {}
 
-  async *collectChangedFiles(batchSize = 10): AsyncIterableIterator<IFileChange[]> {
+  async *collectChangedFiles(reviewConfig: ReviewConfig, batchSize = 10): AsyncIterableIterator<IFileChange[]> {
     try {
       let currentBatch: IFileChange[] = [];
 
-      for await (const files of this.vcsClient.getPullRequestChangesStream(batchSize)) {
+      for await (const files of this.vcsClient.getPullRequestChangesStream(reviewConfig, batchSize)) {
         const filteredFiles = files.filter((file: IFileChange) => this.shouldProcessFile(file));
 
         currentBatch.push(...filteredFiles);

--- a/packages/core/src/files/types.ts
+++ b/packages/core/src/files/types.ts
@@ -1,3 +1,4 @@
+import type { ReviewConfig } from '@code-hedgehog/processor-base';
 import type { IFileChange } from '../types/mod.ts';
 
 export interface IFileFilter {
@@ -27,8 +28,9 @@ export interface IFileFilter {
 export interface IFileManager {
   /**
    * Collects and filters changed files from PR
+   * @param reviewConfig .coderabbitai.yaml file configurations
    * @param batchSize Number of files to process in each batch
    * @returns AsyncIterator of filtered file changes
    */
-  collectChangedFiles(batchSize?: number): AsyncIterableIterator<IFileChange[]>;
+  collectChangedFiles(reviewConfig: ReviewConfig, batchSize?: number): AsyncIterableIterator<IFileChange[]>;
 }

--- a/packages/core/src/types/vcs.ts
+++ b/packages/core/src/types/vcs.ts
@@ -2,6 +2,7 @@
  * Version Control System types
  */
 
+import type { ReviewConfig } from '@code-hedgehog/processor-base';
 import type { IFileChange } from './file.ts';
 import type { IReviewComment } from './review.ts';
 
@@ -95,9 +96,10 @@ export interface IVersionControlSystem {
 
   /**
    * Creates an async iterator that yields batches of file changes
+   * @param reviewConfig .coderabbitai.yaml file configurations
    * @param batchSize Number of files to process in each batch
    */
-  getPullRequestChangesStream(batchSize?: number): AsyncIterableIterator<IFileChange[]>;
+  getPullRequestChangesStream(reviewConfig: ReviewConfig, batchSize?: number): AsyncIterableIterator<IFileChange[]>;
 
   /**
    * Creates a review with a batch of comments

--- a/packages/core/src/vcs/base.ts
+++ b/packages/core/src/vcs/base.ts
@@ -1,3 +1,4 @@
+import type { ReviewConfig } from '@code-hedgehog/processor-base';
 import type { IFileChange, IPullRequestInfo, IReviewComment, IVCSConfig, IVersionControlSystem, VCSType } from '../types/mod.ts';
 
 /**
@@ -15,7 +16,7 @@ export abstract class BaseVCS implements IVersionControlSystem {
   }
 
   abstract getPullRequestInfo(): Promise<IPullRequestInfo>;
-  abstract getPullRequestChangesStream(batchSize?: number): AsyncIterableIterator<IFileChange[]>;
+  abstract getPullRequestChangesStream(reviewConfig: ReviewConfig, batchSize?: number): AsyncIterableIterator<IFileChange[]>;
   abstract createReviewBatch(comments: IReviewComment[], dryRun?: boolean): Promise<void>;
 
   /**

--- a/packages/core/src/vcs/github.test.ts
+++ b/packages/core/src/vcs/github.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CONFIG } from '@code-hedgehog/processor-base';
 import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 import { spy } from '@std/testing/mock';
@@ -43,7 +44,7 @@ describe('GitHubVCS', () => {
     const vcs = new GitHubVCS(config, () => mockOctokit);
     const changes: IFileChange[] = [];
 
-    for await (const batch of vcs.getPullRequestChangesStream(2)) {
+    for await (const batch of vcs.getPullRequestChangesStream(DEFAULT_CONFIG, 2)) {
       changes.push(...batch);
     }
 

--- a/packages/core/src/vcs/github.ts
+++ b/packages/core/src/vcs/github.ts
@@ -7,6 +7,7 @@
  */
 import * as core from '@actions/core';
 import { getOctokit } from '@actions/github';
+import type { ReviewConfig } from '@code-hedgehog/processor-base';
 import type { ICommitComparisonShas, IFileChange, IPullRequestInfo, IReviewComment, IVCSConfig } from '../types/mod.ts';
 import { BaseVCS } from './base.ts';
 import type { CreateGitHubAPI, IGitHubAPI } from './github.types.ts';
@@ -170,14 +171,20 @@ export class GitHubVCS extends BaseVCS {
    * - File size limits (skips patches larger than 1MB)
    * - Total file count limits (warns after 3000 files)
    *
+   * @param reviewConfig .coderabbitai.yaml file configurations
    * @param batchSize Number of files to include in each yielded batch
    */
-  async *getPullRequestChangesStream(batchSize = 10): AsyncIterableIterator<IFileChange[]> {
+  async *getPullRequestChangesStream(reviewConfig: ReviewConfig, batchSize = 10): AsyncIterableIterator<IFileChange[]> {
     try {
       // Optimize page size based on batch size to reduce API calls
       const pageSize = Math.min(100, Math.max(batchSize * 2, 30));
 
-      const shaRange = await this.getShaRangeSinceLastIssueComment();
+      let shaRange: ICommitComparisonShas | undefined;
+
+      // If review_diff_since_last_review is enabled, fetch the SHA range since the last issue comment
+      if (reviewConfig.review_diff_since_last_review) {
+        shaRange = await this.getShaRangeSinceLastIssueComment();
+      }
 
       const iterator = this.api.paginate.iterator(
         shaRange != null

--- a/packages/processors/base/internal/load-base-config.ts
+++ b/packages/processors/base/internal/load-base-config.ts
@@ -19,6 +19,7 @@ const BaseConfigSchema = z
     file_path_instructions: z.array(PathInstructionSchema).optional(),
     path_filters: z.string().optional(),
     skip_simple_changes: z.boolean().optional(),
+    review_diff_since_last_review: z.boolean().optional(),
     // path_instructions is required in ReviewConfig, but might be missing in YAML
     path_instructions: z.array(PathInstructionSchema).optional(),
   })
@@ -85,6 +86,7 @@ export async function loadBaseConfig(configPath = '.coderabbitai.yaml'): Promise
     file_path_instructions: parsedYaml.file_path_instructions ?? DEFAULT_CONFIG.file_path_instructions,
     path_filters: parsedYaml.path_filters ?? DEFAULT_CONFIG.path_filters,
     skip_simple_changes: parsedYaml.skip_simple_changes ?? DEFAULT_CONFIG.skip_simple_changes,
+    review_diff_since_last_review: parsedYaml.review_diff_since_last_review ?? DEFAULT_CONFIG.review_diff_since_last_review,
     // path_instructions is required in ReviewConfig, ensure it defaults correctly
     path_instructions: parsedYaml.path_instructions ?? DEFAULT_CONFIG.path_instructions,
   };

--- a/packages/processors/base/mod.ts
+++ b/packages/processors/base/mod.ts
@@ -2,3 +2,4 @@ export * from './processor.ts';
 export * from './schema.ts';
 export * from './types.ts';
 export * from './utils/summary.ts';
+export * from './internal/load-base-config.ts';

--- a/packages/processors/base/schema.ts
+++ b/packages/processors/base/schema.ts
@@ -91,6 +91,7 @@ export const ConfigSchema = z.object({
   file_path_instructions: z.array(PathInstructionSchema).optional(),
   path_filters: z.string().optional(),
   skip_simple_changes: z.boolean().optional().default(false),
+  review_diff_since_last_review: z.boolean().optional().default(false),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -102,5 +103,6 @@ export const DEFAULT_CONFIG: ReviewConfig = {
   file_path_instructions: [], // Local extension
   path_filters: ['!dist/**', '!**/*.min.js', '!**/*.map', '!**/node_modules/**'].join('\n'),
   skip_simple_changes: false,
+  review_diff_since_last_review: false,
   severityThreshold: 3, // Default threshold for comment severity (1-5)
 };

--- a/packages/processors/base/types.ts
+++ b/packages/processors/base/types.ts
@@ -30,11 +30,12 @@ export interface PathInstruction {
 
 // Base review configuration extending the core config
 export interface LocalReviewConfig {
-  language?: string;
-  file_path_instructions?: PathInstruction[];
-  path_filters?: string;
-  skip_simple_changes?: boolean;
-  severityThreshold?: number; // Threshold for comment severity (1-5, default: 3)
+  language: string;
+  file_path_instructions: PathInstruction[];
+  path_filters: string;
+  skip_simple_changes: boolean;
+  review_diff_since_last_review: boolean;
+  severityThreshold: number; // Threshold for comment severity (1-5, default: 3)
 }
 
 // Combined review configuration using the imported alias


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/166453

## やったこと
- [ram-lab][code-hedgehog] 前回レビュー時からの差分を見るかどうかをオプションで制御できる

## 背景
- 過去に「前回 push 時点から今回 push 時点までの diff を見れる」の対応を行ったが、dry run での実行がメインなら、常に PR 全体の diff を見る方が良い
  - そのため、 `.coderabbitai.yaml` でどの範囲を見るか指定できるようにする

## スクリーンショット
### review_diff_since_last_review: true の時
- 前回レビュー時 (最後についた issue comment) から現在までの差分を見る
![image](https://github.com/user-attachments/assets/bbb2f6ea-e01c-4872-9174-66cacc7553c4)

### review_diff_since_last_review: false もしくは設定なしの時
-  PR の差分全体を見る
![image](https://github.com/user-attachments/assets/b5d22272-1ddd-4b02-befa-6fc8e4bbb4f5)
