### PR TITLE
Imprv/166579 166580 improve github diff position

### DIFF
--- a/packages/core/src/vcs/github.ts
+++ b/packages/core/src/vcs/github.ts
@@ -332,7 +332,8 @@ export class GitHubVCS extends BaseVCS {
           event: 'COMMENT',
           comments: inlineComments.map((comment) => ({
             path: comment.path,
-            position: comment.position,
+            line: comment.position,
+            side: 'RIGHT',
             body: comment.body,
           })),
         });

--- a/packages/playground/src/components/PullRequestDetail.tsx
+++ b/packages/playground/src/components/PullRequestDetail.tsx
@@ -202,9 +202,9 @@ const PullRequestContent = ({ pullRequest, githubToken, owner, repo, number }: P
                     <div className="flex items-center text-xs text-muted-foreground bg-muted p-2 rounded mt-3">
                       <FileCode className="h-3.5 w-3.5 mr-1" />
                       <span className="mr-2">{comment.path}:</span>
-                      <span>差分内で上から {comment.position ?? '-'} 行目の位置</span>
+                      <span>{comment.position ?? '-'} 行</span>
                       <a
-                        href={`https://github.com/${owner}/${repo}/pull/${number}/files#diff-${comment.diffId}`}
+                        href={`https://github.com/${owner}/${repo}/pull/${number}/files#diff-${comment.diffId}${comment.position != null ? `R${comment.position}` : ''}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="ml-auto flex items-center text-primary hover:text-primary/80"

--- a/packages/processors/base/processor.ts
+++ b/packages/processors/base/processor.ts
@@ -297,52 +297,6 @@ export abstract class BaseProcessor implements IPullRequestProcessor {
   }
 
   /**
-   * Add line numbers to diff text for GitHub 'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews' API
-   */
-  protected addLineNumbersToDiff(diffText: string | null): string {
-    if (diffText == null) {
-      return 'No changes';
-    }
-
-    const lines = diffText.split('\n');
-    const numberedLines: string[] = [];
-    let oldLineNumber = 0;
-    let newLineNumber = 0;
-
-    for (const line of lines) {
-      if (line.startsWith('@@')) {
-        // Extract starting line numbers from hunk header
-        // Example: @@ -86,11 +88,11 @@ → old file starts at line 86, new file starts at line 88
-        const match = line.match(/^@@ -(\d+),?\d* \+(\d+),?\d* @@/);
-        if (match) {
-          oldLineNumber = Number.parseInt(match[1], 10);
-          newLineNumber = Number.parseInt(match[2], 10);
-        }
-        numberedLines.push(line);
-      } else if (line.startsWith('-')) {
-        numberedLines.push(`${oldLineNumber}: ${line}`);
-        oldLineNumber++;
-      } else if (line.startsWith('+')) {
-        numberedLines.push(`${newLineNumber}: ${line}`);
-        newLineNumber++;
-      } else if (line.startsWith(' ') || line === '') {
-        if (line.startsWith(' ')) {
-          numberedLines.push(`${newLineNumber}: ${line}`);
-        } else {
-          numberedLines.push(line);
-        }
-        oldLineNumber++;
-        newLineNumber++;
-      } else {
-        // Other lines (file headers, etc.)
-        numberedLines.push(line);
-      }
-    }
-
-    return numberedLines.join('\n');
-  }
-
-  /**
    * Process comments and separate them by severity
    */
   protected processComments(

--- a/packages/processors/base/utils/formatting.test.ts
+++ b/packages/processors/base/utils/formatting.test.ts
@@ -1,7 +1,13 @@
 import { expect } from '@std/expect';
 // deno-lint-ignore-file no-explicit-any
 import { test } from '@std/testing/bdd';
-import { createCollapsibleSection, createCountedCollapsibleSection, formatFileSummaryTable, formatGroupedComments } from './formatting.ts';
+import {
+  addLineNumbersToDiff,
+  createCollapsibleSection,
+  createCountedCollapsibleSection,
+  formatFileSummaryTable,
+  formatGroupedComments,
+} from './formatting.ts';
 
 import type { GroupedComment } from './group.ts';
 
@@ -74,4 +80,20 @@ test('createCountedCollapsibleSection: delegates', () => {
   const html = createCountedCollapsibleSection('Title', 3, 'Body');
   expect(html).toContain('<summary>Title (3)</summary>');
   expect(html).toContain('Body</details>');
+});
+
+test("addLineNumbersToDiff returns 'No changes' for null", () => {
+  expect(addLineNumbersToDiff(null)).toBe('No changes');
+});
+
+test('addLineNumbersToDiff adds line numbers to unified diff', () => {
+  const diff = ['@@ -1,3 +1,4 @@', ' line1', '-line2', '+line2 modified', ' line3', '+line4', '', 'diff --git a/foo b/foo'].join('\n');
+  const expected = ['@@ -1,3 +1,4 @@', '1:  line1', '2: -line2', '2: +line2 modified', '3:  line3', '4: +line4', '', 'diff --git a/foo b/foo'].join('\n');
+  expect(addLineNumbersToDiff(diff)).toBe(expected);
+});
+
+test('addLineNumbersToDiff handles multiple hunks', () => {
+  const diff = ['@@ -10,2 +10,3 @@', ' lineA', '-lineB', '+lineB changed', '@@ -20,1 +21,2 @@', '+added', ' lineC'].join('\n');
+  const expected = ['@@ -10,2 +10,3 @@', '10:  lineA', '11: -lineB', '11: +lineB changed', '@@ -20,1 +21,2 @@', '21: +added', '22:  lineC'].join('\n');
+  expect(addLineNumbersToDiff(diff)).toBe(expected);
 });

--- a/packages/processors/base/utils/formatting.ts
+++ b/packages/processors/base/utils/formatting.ts
@@ -56,3 +56,49 @@ export function formatFileSummaryTable(fileSummaries: Map<string, string>): stri
 export function createCountedCollapsibleSection(title: string, count: number, content: string): string {
   return createCollapsibleSection(`${title} (${count})`, content);
 }
+
+/**
+ * Add line numbers to diff text for GitHub 'POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews' API
+ */
+export function addLineNumbersToDiff(diffText: string | null): string {
+  if (diffText == null) {
+    return 'No changes';
+  }
+
+  const lines = diffText.split('\n');
+  const numberedLines: string[] = [];
+  let oldLineNumber = 0;
+  let newLineNumber = 0;
+
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      // Extract starting line numbers from hunk header
+      // Example: @@ -86,11 +88,11 @@ → old file starts at line 86, new file starts at line 88
+      const match = line.match(/^@@ -(\d+),?\d* \+(\d+),?\d* @@/);
+      if (match) {
+        oldLineNumber = Number.parseInt(match[1], 10);
+        newLineNumber = Number.parseInt(match[2], 10);
+      }
+      numberedLines.push(line);
+    } else if (line.startsWith('-')) {
+      numberedLines.push(`${oldLineNumber}: ${line}`);
+      oldLineNumber++;
+    } else if (line.startsWith('+')) {
+      numberedLines.push(`${newLineNumber}: ${line}`);
+      newLineNumber++;
+    } else if (line.startsWith(' ') || line === '') {
+      if (line.startsWith(' ')) {
+        numberedLines.push(`${newLineNumber}: ${line}`);
+      } else {
+        numberedLines.push(line);
+      }
+      oldLineNumber++;
+      newLineNumber++;
+    } else {
+      // Other lines (file headers, etc.)
+      numberedLines.push(line);
+    }
+  }
+
+  return numberedLines.join('\n');
+}

--- a/packages/processors/dify/processor.ts
+++ b/packages/processors/dify/processor.ts
@@ -306,7 +306,7 @@ export class DifyProcessor extends BaseProcessor {
             title: prInfo.title,
             description: prInfo.body || '',
             filePath: file.path,
-            patch: file.patch || 'No changes',
+            patch: this.addLineNumbersToDiff(file.patch),
             instructions: this.getInstructionsForFile(file.path, config),
             aspects: {
               transfer_method: 'local_file',

--- a/packages/processors/dify/processor.ts
+++ b/packages/processors/dify/processor.ts
@@ -1,9 +1,9 @@
 import process from 'node:process';
 import type { ReviewConfig } from '../base/types.ts';
-import { formatFileSummaryTable } from '../base/utils/formatting.ts';
+import { addLineNumbersToDiff, formatFileSummaryTable } from '../base/utils/formatting.ts';
 import { mergeOverallSummaries } from '../base/utils/summary.ts';
 import type { IFileChange, IPullRequestInfo, IPullRequestProcessedResult, IReviewComment, OverallSummary, SummarizeResult } from './deps.ts';
-import { BaseProcessor, OverallSummarySchema, type ReviewComment, ReviewCommentSchema, ReviewResponseSchema, SummaryResponseSchema } from './deps.ts';
+import { BaseProcessor, OverallSummarySchema, type ReviewComment, ReviewResponseSchema, SummaryResponseSchema } from './deps.ts';
 import { runWorkflow, uploadFile } from './internal/mod.ts';
 
 // Internal configuration type for DifyProcessor
@@ -306,7 +306,7 @@ export class DifyProcessor extends BaseProcessor {
             title: prInfo.title,
             description: prInfo.body || '',
             filePath: file.path,
-            patch: this.addLineNumbersToDiff(file.patch),
+            patch: addLineNumbersToDiff(file.patch),
             instructions: this.getInstructionsForFile(file.path, config),
             aspects: {
               transfer_method: 'local_file',

--- a/packages/processors/openai/processor.ts
+++ b/packages/processors/openai/processor.ts
@@ -1,12 +1,8 @@
 import process from 'node:process';
-import { ImpactLevel } from '../base/schema.ts';
 // Import the base config type
 import type { ReviewConfig } from '../base/types.ts'; // Use base ReviewConfig
-import { createHorizontalBatches, createVerticalBatches } from '../base/utils/batch.ts';
-import { formatFileSummaryTable } from '../base/utils/formatting.ts';
+import { addLineNumbersToDiff, formatFileSummaryTable } from '../base/utils/formatting.ts';
 import { mergeOverallSummaries } from '../base/utils/summary.ts';
-import { CommentType } from './deps.ts';
-import type { z } from './deps.ts'; // Import zod for type assertion
 import { BaseProcessor, OpenAI, OverallSummarySchema, ReviewResponseSchema, SummaryResponseSchema, zodResponseFormat } from './deps.ts';
 import type {
   IFileChange,
@@ -266,7 +262,7 @@ export class OpenaiProcessor extends BaseProcessor {
           title: prInfo.title,
           description: prInfo.body || '',
           filePath: file.path,
-          patch: this.addLineNumbersToDiff(file.patch),
+          patch: addLineNumbersToDiff(file.patch),
           instructions: this.getInstructionsForFile(file.path, config),
           aspects: summarizeResult.aspects.map((aspect) => ({
             name: aspect.key,


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/166607

## やったこと
- [ram-lab][code-hedgehog] コメントの position とファイルの行数を一致させる
  - Github のコメント作成 API で使用するプロパティを変更 (position -> line)
  - playground で正確な github web ui の diff に飛べるようにした

## スクリーンショット
- コメントカードから適切な位置の差分行に飛べることを確認
![image](https://github.com/user-attachments/assets/1fc6729b-2ac1-472c-bf38-bfb4093f4e63)
